### PR TITLE
BF: Update requirements to match those in rich 12.4.1 pyproject.toml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,22 +12,21 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6.2
+    - python >=3.6.3
     - poetry >=1.0.10
     - poetry-core
   run:
-    - colorama >=0.4.0,<0.5.0
     - commonmark >=0.9.0,<0.10.0
     - dataclasses >=0.7,<0.9
     - pygments >=2.6.0,<3.0.0
     - python >=3.6.2
-    - typing_extensions >=3.7.4,<5.0.0
+    - typing_extensions >=4.0.0,<5.0.0
 
 test:
   imports:


### PR DESCRIPTION
Howdy,

This PR simply the package run-time requirements to match those in the `pyproject.toml` from rich 12.4.1. 

Without these changes it is possible to create a conda environment which contains rich 12.4.1, and typing-extensions <4.0, which results in a run-time error when trying to access pkg_resources entry points. For example (installing rich-cli, as it depends on rich+typing+extensions, and registers an entry point):

```
conda create -c conda-forge -y  -p ./test.env python=3.8 rich-cli "typing-extensions=3.*"
```

<details>

```
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: $HOME/test.env

  added / updated specs:
    - python=3.8
    - rich-cli
    - typing-extensions=3


The following NEW packages will be INSTALLED:

  _libgcc_mutex      conda-forge/linux-64::_libgcc_mutex-0.1-conda_forge
  _openmp_mutex      conda-forge/linux-64::_openmp_mutex-4.5-2_gnu
  brotlipy           conda-forge/linux-64::brotlipy-0.7.0-py38h0a891b7_1004
  bzip2              conda-forge/linux-64::bzip2-1.0.8-h7f98852_4
  ca-certificates    conda-forge/linux-64::ca-certificates-2021.10.8-ha878542_0
  certifi            conda-forge/linux-64::certifi-2021.10.8-py38h578d9bd_2
  cffi               conda-forge/linux-64::cffi-1.15.0-py38h3931269_0
  charset-normalizer conda-forge/noarch::charset-normalizer-2.0.12-pyhd8ed1ab_0
  click              conda-forge/linux-64::click-8.1.3-py38h578d9bd_0
  colorama           conda-forge/noarch::colorama-0.4.4-pyh9f0ad1d_0
  commonmark         conda-forge/noarch::commonmark-0.9.1-py_0
  cryptography       conda-forge/linux-64::cryptography-36.0.2-py38h2b5fc30_1
  dataclasses        conda-forge/noarch::dataclasses-0.8-pyhc8e2a94_3
  docutils           conda-forge/linux-64::docutils-0.18.1-py38h578d9bd_1
  future             conda-forge/linux-64::future-0.18.2-py38h578d9bd_5
  idna               conda-forge/noarch::idna-3.3-pyhd8ed1ab_0
  ld_impl_linux-64   conda-forge/linux-64::ld_impl_linux-64-2.36.1-hea4e1c9_2
  libffi             conda-forge/linux-64::libffi-3.4.2-h7f98852_5
  libgcc-ng          conda-forge/linux-64::libgcc-ng-12.1.0-h8d9b700_16
  libgomp            conda-forge/linux-64::libgomp-12.1.0-h8d9b700_16
  libnsl             conda-forge/linux-64::libnsl-2.0.0-h7f98852_0
  libuuid            conda-forge/linux-64::libuuid-2.32.1-h7f98852_1000
  libzlib            conda-forge/linux-64::libzlib-1.2.11-h166bdaf_1014
  ncurses            conda-forge/linux-64::ncurses-6.3-h27087fc_1
  openssl            conda-forge/linux-64::openssl-1.1.1o-h166bdaf_0
  pip                conda-forge/noarch::pip-22.1-pyhd8ed1ab_0
  pycparser          conda-forge/noarch::pycparser-2.21-pyhd8ed1ab_0
  pygments           conda-forge/noarch::pygments-2.12.0-pyhd8ed1ab_0
  pyopenssl          conda-forge/noarch::pyopenssl-22.0.0-pyhd8ed1ab_0
  pysocks            conda-forge/linux-64::pysocks-1.7.1-py38h578d9bd_5
  python             conda-forge/linux-64::python-3.8.13-h582c2e5_0_cpython
  python_abi         conda-forge/linux-64::python_abi-3.8-2_cp38
  readline           conda-forge/linux-64::readline-8.1-h46c0cb4_0
  requests           conda-forge/noarch::requests-2.27.1-pyhd8ed1ab_0
  rich               conda-forge/noarch::rich-12.4.1-pyhd8ed1ab_0
  rich-cli           conda-forge/noarch::rich-cli-1.8.0-pyhd8ed1ab_0
  rich-rst           conda-forge/noarch::rich-rst-1.1.7-pyhd8ed1ab_0
  setuptools         conda-forge/linux-64::setuptools-62.2.0-py38h578d9bd_0
  sqlite             conda-forge/linux-64::sqlite-3.38.5-h4ff8645_0
  textual            conda-forge/noarch::textual-0.1.18-pyhd8ed1ab_0
  tk                 conda-forge/linux-64::tk-8.6.12-h27826a3_0
  typing-extensions  conda-forge/noarch::typing-extensions-3.10.0.2-hd8ed1ab_0
  typing_extensions  conda-forge/noarch::typing_extensions-3.10.0.2-pyha770c72_0
  urllib3            conda-forge/noarch::urllib3-1.26.9-pyhd8ed1ab_0
  wheel              conda-forge/noarch::wheel-0.37.1-pyhd8ed1ab_0
  xz                 conda-forge/linux-64::xz-5.2.5-h516909a_1
  zlib               conda-forge/linux-64::zlib-1.2.11-h166bdaf_1014


Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate $HOME/test.env
#
# To deactivate an active environment, use
#
#     $ conda deactivate
```

</details>

```
./test.env/bin/python
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:04:10)
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pkg_resources
>>> for ep in pkg_resources.iter_entry_points('console_scripts'):
...     ep.load()
...
<function main at 0x7f45a90139d0>
<function main at 0x7f45a90139d0>
<function main at 0x7f45a90139d0>
<function main at 0x7f45a7c88af0>
<function cli_detect at 0x7f45a7c62670>
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "$HOME/test.env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2470, in load
    self.require(*args, **kwargs)
  File "$HOME/test.env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2493, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "$HOME/test.env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 800, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (typing-extensions 3.10.0.2 ($HOME/test.env/lib/python3.8/site-packages), Requirement.parse('typing-extensions<5.0,>=4.0.0; python_version < "3.9"'), {'rich', 'textual'})
>>>
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
